### PR TITLE
Fix placeholder prop casing

### DIFF
--- a/components/DocumentManagement.js
+++ b/components/DocumentManagement.js
@@ -24,7 +24,7 @@ export default function DocumentManagement(props) {
       <label>
         Title
         <input
-          placeHolder="Title"
+          placeholder="Title"
           value={title}
           onChange={(event) => setTitle(event.target.value)}
         />


### PR DESCRIPTION
Prevents this error:

```
Warning: Invalid DOM property `placeHolder`. Did you mean `placeholder`?
    at input
    at label
    at div
    at eval (/home/projects/zzmilbpkw.github/node_modules/@emotion/react/dist/emotion-element-e89f38a3.cjs.dev.js:72:25)
    at DocumentManagement (webpack-internal:///./components/DocumentManagement.js:28:54)
    at div
    at eval (/home/projects/zzmilbpkw.github/node_modules/@emotion/react/dist/emotion-element-e89f38a3.cjs.dev.js:72:25)
    at Sidebar (webpack-internal:///./components/Sidebar.js:46:54)
    at div
    at eval (/home/projects/zzmilbpkw.github/node_modules/@emotion/react/dist/emotion-element-e89f38a3.cjs.dev.js:72:25)
    at div
    at main
    at Layout (webpack-internal:///./components/Layout.js:49:54)
    at div
    at Home
    at MyApp (webpack-internal:///./pages/_app.js:21:3)
    at StyleRegistry (/home/projects/zzmilbpkw.github/node_modules/styled-jsx/dist/index/index.js:671:34)
    at AppContainer (/home/projects/zzmilbpkw.github/node_modules/next/dist/server/render.js:415:29)
    at AppContainerWithIsomorphicFiberStructure (/home/projects/zzmilbpkw.github/node_modules/next/dist/server/render.js:447:57)
    at div
    at Body (/home/projects/zzmilbpkw.github/node_modules/next/dist/server/render.js:715:21)
```